### PR TITLE
cache total word counts per category

### DIFF
--- a/lib/classifier/bayes.rb
+++ b/lib/classifier/bayes.rb
@@ -56,7 +56,7 @@ class Bayes
 					count = orig
 				end
 
-				if @category_word_count[category] > count
+				if @category_word_count[category] >= count
 					@category_word_count[category] -= count
 				end
 				@total_words -= count

--- a/lib/classifier/bayes.rb
+++ b/lib/classifier/bayes.rb
@@ -73,10 +73,10 @@ class Bayes
 		score = Hash.new
 		@categories.each do |category, category_words|
 			score[category.to_s] = 0
-			total = @category_word_count[category] || 1
+			total = (@category_word_count[category] || 1).to_f
 			text.word_hash.each do |word, count|
 				s = category_words.has_key?(word) ? category_words[word] : 0.1
-				score[category.to_s] += Math.log(s/total.to_f)
+				score[category.to_s] += Math.log(s/total)
 			end
 		end
 		return score

--- a/lib/classifier/bayes.rb
+++ b/lib/classifier/bayes.rb
@@ -71,10 +71,11 @@ class Bayes
 	# The largest of these scores (the one closest to 0) is the one picked out by #classify
 	def classifications(text)
 		score = Hash.new
+		word_hash = text.word_hash
 		@categories.each do |category, category_words|
 			score[category.to_s] = 0
 			total = (@category_word_count[category] || 1).to_f
-			text.word_hash.each do |word, count|
+			word_hash.each do |word, count|
 				s = category_words.has_key?(word) ? category_words[word] : 0.1
 				score[category.to_s] += Math.log(s/total)
 			end


### PR DESCRIPTION
Original code recalculated total word count per category for each classification.
On large datasets, this is really expensive.

On my dataset with 58k records in training set and 11k records in classifying set,
classification times improved from 1560 seconds to 107 seconds, and training time
only went from 593 to 691 seconds.
