### PR TITLE
performance: speedup word_hash

### DIFF
--- a/lib/classifier/extensions/word_hash.rb
+++ b/lib/classifier/extensions/word_hash.rb
@@ -35,9 +35,8 @@ class String
 		d = Hash.new(0)
 		words.each do |word|
 			word.downcase!
-			key = word.stem.intern
 			if ! CORPUS_SKIP_WORDS.include?(word) && word.length > 2
-				d[key] += 1
+				d[word.stem.intern] += 1
 			end
 		end
 		return d
@@ -47,8 +46,7 @@ class String
 	def word_hash_for_symbols(words)
 		d = Hash.new(0)
 		words.each do |word|
-			key = word.intern
-			d[key] += 1
+			d[word.intern] += 1
 		end
 		return d
 	end


### PR DESCRIPTION
My training times went from 806 seconds down to 662 seconds (60k records)
with these minor changes to String.word_hash().
