### PR TITLE
only perform first order transform if total UNIQUE words is greater than 1

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,0 +1,36 @@
+Gem::Specification.new do |s|
+  #### Basic information.
+
+  s.name = 'classifier'
+  s.version = PKG_VERSION
+  s.version = "#{s.version}-alpha-#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
+  s.summary = <<-EOF
+   A general classifier module to allow Bayesian and other types of classifications.
+  EOF
+  s.description = <<-EOF
+   A general classifier module to allow Bayesian and other types of classifications.
+  EOF
+
+  #### Which files are to be included in this gem?  Everything!  (Except CVS directories.)
+
+  s.files = PKG_FILES
+
+  #### Load-time details: library and application (you will need one or both).
+
+  s.require_path = 'lib'
+  s.autorequire = 'classifier'
+
+  #### Documentation and testing.
+
+  s.has_rdoc = true
+
+  #### Dependencies and requirements.
+
+  s.add_dependency('fast-stemmer', '>= 1.0.0')
+  s.requirements << "A porter-stemmer module to split word stems."
+
+  #### Author and project details.
+  s.author = "Lucas Carlson"
+  s.email = "lucas@rufy.com"
+  s.homepage = "http://classifier.rufy.com/"
+end

--- a/lib/classifier/lsi/content_node.rb
+++ b/lib/classifier/lsi/content_node.rb
@@ -42,22 +42,23 @@ module Classifier
       @word_hash.each_key do |word|
         vec[word_list[word]] = @word_hash[word] if word_list[word]
       end
-     
+
       # Perform the scaling transform
       total_words = vec.sum
-      
+      total_unique_words = vec.count{|word| word != 0}
+
       # Perform first-order association transform if this vector has more
-      # than one word in it. 
-      if total_words > 1.0 
+      # than one word in it.
+      if total_words > 1.0 && total_unique_words > 1
         weighted_total = 0.0
         vec.each do |term|
           if ( term > 0 )
             weighted_total += (( term / total_words ) * Math.log( term / total_words ))
           end
-        end 
+        end
         vec = vec.collect { |val| Math.log( val + 1 ) / -weighted_total }
       end
-      
+
       if $GSL
          @raw_norm   = vec.normalize
          @raw_vector = vec
@@ -65,8 +66,7 @@ module Classifier
          @raw_norm   = Vector[*vec].normalize
          @raw_vector = Vector[*vec]
       end
-    end   
-  
+    end
   end  
   
 end


### PR DESCRIPTION
Instead of summing up the vector to count total words, count how many entries in the vector are non-zero. This prevents a divide by 0 on line 59 happening in some cases. Not totally sure if this will mess up the algorithm, but I tried to leave things alone as much as possible

Addresses https://github.com/cardmagic/classifier/issues/18
