### PR TITLE
Only require mathn for Ruby >= 2.5 (to be consistent with gemspec)

### DIFF
--- a/lib/classifier/extensions/vector.rb
+++ b/lib/classifier/extensions/vector.rb
@@ -4,7 +4,7 @@
 # These are extensions to the std-lib 'matrix' to allow an all ruby SVD
 
 require 'matrix'
-require 'mathn'
+require 'mathn' if RUBY_VERSION >= '2.5'
 
 class Array
   def sum(identity = 0, &block)


### PR DESCRIPTION
Hey there, unless you do this, the gem is unusable outside of Ruby 2.5, which I don't think was the intention here.