### PR TITLE
Compatibility with ruby >= 2.7 without GSL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ If you install Classifier from source, you'll need to install Roman Shterenzon's
 
 If you would like to speed up LSI classification by at least 10x, please install the following libraries:
 GNU GSL:: http://www.gnu.org/software/gsl
-rb-gsl:: http://rb-gsl.rubyforge.org
+rb-gsl:: https://github.com/SciRuby/rb-gsl
 
 Notice that LSI will work without these libraries, but as soon as they are installed, Classifier will make use of them. No configuration changes are needed, we like to keep things ridiculously easy for you.
 

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -10,7 +10,10 @@ Gem::Specification.new do |s|
   s.license = 'LGPL'
 
   s.add_dependency 'fast-stemmer', '~> 1.0.0'
+  # mathn deprecated and removed in >= 2.5
   s.add_dependency 'mathn' if RUBY_VERSION >= '2.5'
+  # cmath moved to gem, mathn depends on cmath, but won't be updated due to deprecation
+  s.add_dependency 'cmath' if RUBY_VERSION >= '2.7'
   s.add_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rdoc'

--- a/lib/classifier/lsi.rb
+++ b/lib/classifier/lsi.rb
@@ -3,15 +3,16 @@
 # License::   LGPL
 
 begin
-   raise LoadError if ENV['NATIVE_VECTOR'] == "true" # to test the native vector class, try `rake test NATIVE_VECTOR=true`
+  raise LoadError if ENV['NATIVE_VECTOR'] == "true" # to test the native vector class, try `rake test NATIVE_VECTOR=true`
 
-   require 'gsl' # requires http://rb-gsl.rubyforge.org/
-   require 'classifier/extensions/vector_serialize'
-   $GSL = true
+  require 'gsl' # requires https://github.com/SciRuby/rb-gsl/
+  require 'classifier/extensions/vector_serialize'
+  $GSL = true
 
 rescue LoadError
-	warn "Notice: for 10x faster LSI support, please install http://rb-gsl.rubyforge.org/"
-	require 'classifier/extensions/vector'
+  warn "Notice: for 10x faster LSI support, please install https://github.com/SciRuby/rb-gsl/"
+  $GSL = false
+  require 'classifier/extensions/vector'
 end
 
 require 'classifier/lsi/word_list'


### PR DESCRIPTION
`classifier/extensions/vector` is loaded when GSL is not found, this requires use of `mathn` which was deprecated and then removed in ruby >= 2.5. The mathn gem requires `cmath` which is now a gem. In order to keep things ridiculously simple, I've updated the gem spec dependencies to include cmath.

Along the same vane, rubyforge closed down and rb-gsl is now located at https://github.com/SciRuby/rb-gsl