### PR TITLE
Fix race condition bug deleting categories

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head']
+        ruby-version: ['2.7', 'head']
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec
 
 gem 'fast-stemmer'
 gem 'matrix'
+gem 'mutex_m'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     classifier (1.4.2)
-      fast-stemmer (~> 1.0.0)
+      fast-stemmer (~> 1.0)
+      mutex_m (~> 0.2)
       rake
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    classifier (1.4.1)
+    classifier (1.4.2)
       fast-stemmer (~> 1.0.0)
       rake
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     fast-stemmer (1.0.2)
     matrix (0.4.2)
     minitest (5.18.1)
+    mutex_m (0.2.0)
     psych (5.1.2)
       stringio
     rake (13.0.6)
@@ -28,6 +29,7 @@ DEPENDENCIES
   fast-stemmer
   matrix
   minitest
+  mutex_m
   rdoc
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    classifier (1.4.0)
+    classifier (1.4.1)
       fast-stemmer (~> 1.0.0)
       rake
 

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'classifier'
-  s.version     = '1.4.1'
+  s.version     = '1.4.2'
   s.summary     = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.description = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.author = 'Lucas Carlson'

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*.rb', 'bin/*', 'LICENSE', '*.md', 'test/*']
   s.license = 'LGPL'
 
-  s.add_dependency 'fast-stemmer', '~> 1.0.0'
+  s.add_dependency 'fast-stemmer', '~> 1.0'
+  s.add_dependency 'mutex_m', '~> 0.2'
   s.add_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rdoc'

--- a/lib/classifier/bayes.rb
+++ b/lib/classifier/bayes.rb
@@ -152,10 +152,11 @@ module Classifier
       category = category.prepare_category_name
       raise StandardError, "No such category: #{category}" unless @categories.key?(category)
 
+      @total_words -= @category_word_count[category].to_i
+
       @categories.delete(category)
       @category_counts.delete(category)
       @category_word_count.delete(category)
-      @total_words -= @category_word_count[category].to_i
     end
   end
 end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -94,4 +94,34 @@ class BayesianTest < Minitest::Test
 
     assert_equal interesting_classification, @classifier.classify('This is interesting')
   end
+
+  def test_remove_category
+    initial_total_words = @classifier.instance_variable_get(:@total_words)
+    category_word_count = @classifier.instance_variable_get(:@category_word_count)['Interesting']
+
+    @classifier.remove_category('Interesting')
+
+    assert_nil @classifier.instance_variable_get(:@categories)['Interesting']
+    assert_equal @classifier.instance_variable_get(:@category_counts)['Interesting'], 0
+    assert_equal @classifier.instance_variable_get(:@category_word_count)['Interesting'], 0
+
+    new_total_words = @classifier.instance_variable_get(:@total_words)
+    assert_equal initial_total_words - category_word_count, new_total_words
+  end
+
+  def test_remove_category_updates_total_words_before_deletion
+    initial_total_words = @classifier.instance_variable_get(:@total_words)
+    category_word_count = @classifier.instance_variable_get(:@category_word_count)['Interesting']
+
+    @classifier.remove_category('Interesting')
+
+    new_total_words = @classifier.instance_variable_get(:@total_words)
+    assert_equal initial_total_words - category_word_count, new_total_words
+  end
+
+  def test_remove_nonexistent_category
+    assert_raises(StandardError, 'No such category: Nonexistent Category') do
+      @classifier.remove_category('Nonexistent Category')
+    end
+  end
 end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -54,12 +54,6 @@ class BayesianTest < Minitest::Test
     assert_equal ['Interesting'], @classifier.categories
   end
 
-  def test_remove_nonexistent_category
-    assert_raises(StandardError) do
-      @classifier.remove_category 'NonexistentCategory'
-    end
-  end
-
   def test_remove_category_affects_classification
     @classifier.train_interesting 'This is interesting content'
     @classifier.train_uninteresting 'This is uninteresting content'
@@ -95,7 +89,7 @@ class BayesianTest < Minitest::Test
     assert_equal interesting_classification, @classifier.classify('This is interesting')
   end
 
-  def test_remove_category
+  def test_remove_category_check_counts
     initial_total_words = @classifier.instance_variable_get(:@total_words)
     category_word_count = @classifier.instance_variable_get(:@category_word_count)['Interesting']
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,5 @@
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 
-require 'mutex_m'
 require 'minitest'
 require 'minitest/autorun'
 require 'classifier'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 
+require 'mutex_m'
 require 'minitest'
 require 'minitest/autorun'
 require 'classifier'


### PR DESCRIPTION
## Changes Overview

These changes primarily focus on updating the Ruby gem version, modifying the CI workflow, and improving the Bayesian classifier functionality. The main modifications include:

1. Updating the Ruby versions tested in the CI workflow.
2. Incrementing the gem version.
3. Modifying the `remove_category` method in the Bayesian classifier.
4. Adding new tests for the `remove_category` functionality.

## Reason for Changes

The changes aim to update the gem's compatibility, improve its version tracking, and enhance the robustness of the Bayesian classifier's category removal feature.

## Detailed Description

1. **CI Workflow Update** - The `.github/workflows/ruby.yml` file has been modified to test fewer Ruby versions, now only including '2.7' and 'head'. This change likely aims to focus testing on the oldest supported version and the latest development version.

2. **Gem Version Update** - The gem version has been incremented from 1.4.1 to 1.4.2 in the `classifier.gemspec` file. This indicates a minor update or bug fix release.

3. **Bayesian Classifier Improvement** - The `remove_category` method in `lib/classifier/bayes.rb` has been modified to update the `@total_words` count before deleting the category data. This ensures that the total word count is accurately maintained even when categories are removed.

4. **New Tests** - Three new tests have been added to `test/bayes/bayesian_test.rb` to verify the correct functionality of the `remove_category` method:
   - A test to ensure that category data is properly removed.
   - A test to confirm that the total word count is updated correctly.
   - A test to check that an error is raised when attempting to remove a non-existent category.