### PR TITLE
Fix: LoadError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     classifier (1.4.4)
       fast-stemmer (~> 1.0)
+      matrix
       mutex_m (~> 0.2)
       rake
 
@@ -23,6 +24,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'fast-stemmer', '~> 1.0'
   s.add_dependency 'mutex_m', '~> 0.2'
   s.add_dependency 'rake'
+  s.add_dependency 'matrix'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
Fix the following LoadError for Ruby 3.1+ 🙂 

```
/Users/maxhungry/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/classifier-1.4.4/lib/classifier/extensions/vector.rb:6: warning: matrix was loaded from the standard library, but is not part of the default gems starting from Ruby 3.1.0.
You can add matrix to your Gemfile or gemspec to silence this warning.
Also please contact the author of classifier-1.4.4 to request adding matrix into its gemspec.
/Users/maxhungry/.local/share/mise/installs/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- matrix (LoadError)
```