### PR TITLE
Fix Gemfile.lock to include matrix dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     classifier (1.4.4)
       fast-stemmer (~> 1.0)
+      matrix
       mutex_m (~> 0.2)
       rake
 


### PR DESCRIPTION
## Summary
Sync Gemfile.lock with gemspec after matrix dependency was added in PR #42.

Fixes #46

## Test plan
- [ ] CI passes on all Ruby versions