### PR TITLE
Add RuboCop for code standardization

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,8 +17,19 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+    - name: Run RuboCop
+      run: bundle exec rubocop
 
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,96 @@
+plugins:
+  - rubocop-minitest
+
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  Exclude:
+    - 'vendor/**/*'
+    - 'coverage/**/*'
+    - '*.gemspec'
+    - 'bin/**/*'
+    - 'install.rb'
+
+# Existing code lacks documentation, can add incrementally
+Style/Documentation:
+  Enabled: false
+
+# Test files often have long blocks
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+    - 'lib/classifier/extensions/vector.rb'
+
+# Allow longer methods in complex algorithms (SVD, etc.)
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - 'test/**/*'
+    - 'lib/classifier/extensions/vector.rb'
+    - 'lib/classifier/lsi/content_node.rb'
+
+# Allow higher complexity for mathematical algorithms
+Metrics/AbcSize:
+  Max: 30
+  Exclude:
+    - 'test/**/*'
+    - 'lib/classifier/extensions/vector.rb'
+    - 'lib/classifier/lsi.rb'
+    - 'lib/classifier/lsi/content_node.rb'
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+  Exclude:
+    - 'lib/classifier/extensions/vector.rb'
+    - 'lib/classifier/lsi/content_node.rb'
+
+Metrics/PerceivedComplexity:
+  Max: 10
+  Exclude:
+    - 'lib/classifier/extensions/vector.rb'
+    - 'lib/classifier/lsi/content_node.rb'
+
+# Class length limits - algorithms and tests can be longer
+Metrics/ClassLength:
+  Max: 250
+  Exclude:
+    - 'test/**/*'
+
+# SV_decomp is a standard algorithm name
+Naming/MethodName:
+  Exclude:
+    - 'lib/classifier/extensions/vector.rb'
+
+# Short parameter names are acceptable for serialization
+Naming/MethodParameterName:
+  Exclude:
+    - 'lib/classifier/extensions/vector_serialize.rb'
+
+# Marshal.load is intentional for deserialization
+Security/MarshalLoad:
+  Exclude:
+    - 'lib/classifier/extensions/vector_serialize.rb'
+    - 'test/**/*'
+
+# CORPUS_SKIP_WORDS is a public constant used externally
+Lint/UselessConstantScoping:
+  Enabled: false
+
+# Frozen string literal is optional for this gem
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Allow compact class/module child definitions
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# Allow both styles of string literals
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+
+# Minitest assertions
+Minitest/MultipleAssertions:
+  Max: 10

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,8 @@ gem 'mutex_m'
 group :test do
   gem 'simplecov', require: false
 end
+
+group :development do
+  gem 'rubocop', require: false
+  gem 'rubocop-minitest', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,16 +10,47 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     docile (1.4.1)
     fast-stemmer (1.0.2)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     matrix (0.4.2)
     minitest (5.18.1)
     mutex_m (0.2.0)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.7.0)
     psych (5.1.2)
       stringio
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     rdoc (6.5.1.1)
       psych (>= 4.0.0)
+    regexp_parser (2.11.3)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.48.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-minitest (0.38.2)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -27,6 +58,9 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     stringio (3.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   arm64-darwin-22
@@ -41,6 +75,8 @@ DEPENDENCIES
   minitest
   mutex_m
   rdoc
+  rubocop
+  rubocop-minitest
   simplecov
 
 BUNDLED WITH

--- a/lib/classifier/bayes.rb
+++ b/lib/classifier/bayes.rb
@@ -88,7 +88,7 @@ module Classifier
     #    b.classify "I hate bad words and you"
     #    =>  'Uninteresting'
     def classify(text)
-      (classifications(text).sort_by { |a| -a[1] })[0][0]
+      classifications(text).min_by { |a| -a[1] }[0]
     end
 
     #
@@ -107,6 +107,10 @@ module Classifier
 
       method = name.to_s.start_with?('untrain_') ? :untrain : :train
       args.each { |text| send(method, category, text) }
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      name.to_s =~ /(un)?train_(\w+)/ || super
     end
 
     #

--- a/lib/classifier/extensions/vector.rb
+++ b/lib/classifier/extensions/vector.rb
@@ -6,11 +6,11 @@
 require 'matrix'
 
 class Array
-  def sum_with_identity(identity = 0.0, &block)
+  def sum_with_identity(identity = 0.0, &)
     return identity unless size.to_i.positive?
-    return map(&block).sum_with_identity(identity) if block_given?
+    return map(&).sum_with_identity(identity) if block_given?
 
-    compact.reduce(:+).to_f || identity.to_f
+    compact.reduce(identity, :+).to_f
   end
 end
 
@@ -58,8 +58,8 @@ class Matrix
 
     loop do
       iteration_count += 1
-      (0...q_rotation_matrix.row_size - 1).each do |row|
-        (1..q_rotation_matrix.row_size - 1).each do |col|
+      (0...(q_rotation_matrix.row_size - 1)).each do |row|
+        (1..(q_rotation_matrix.row_size - 1)).each do |col|
           next if row == col
 
           angle = Math.atan((2.to_r * q_rotation_matrix[row,

--- a/lib/classifier/extensions/word_hash.rb
+++ b/lib/classifier/extensions/word_hash.rb
@@ -12,7 +12,7 @@ class String
   #   "Hello (greeting's), with {braces} < >...?".without_punctuation
   #   => "Hello  greetings   with  braces         "
   def without_punctuation
-    tr(',?.!;:"@#$%^&*()_=+[]{}\|<>/`~', ' ').tr("'\-", '')
+    tr(',?.!;:"@#$%^&*()_=+[]{}|<>/`~', ' ').tr("'-", '')
   end
 
   # Return a Hash of strings => ints. Each word in the string is stemmed,

--- a/lib/classifier/lsi.rb
+++ b/lib/classifier/lsi.rb
@@ -165,7 +165,7 @@ module Classifier
       avg_density = {}
       @items.each_key { |x| avg_density[x] = proximity_array_for_content(x).inject(0.0) { |i, j| i + j[1] } }
 
-      avg_density.keys.sort_by { |x| avg_density[x] }.reverse[0..max_chunks - 1].map
+      avg_density.keys.sort_by { |x| avg_density[x] }.reverse[0..(max_chunks - 1)].map
     end
 
     # This function is the primitive that find_related and classify
@@ -180,10 +180,10 @@ module Classifier
     # The parameter doc is the content to compare. If that content is not
     # indexed, you can pass an optional block to define how to create the
     # text data. See add_item for examples of how this works.
-    def proximity_array_for_content(doc, &block)
+    def proximity_array_for_content(doc, &)
       return [] if needs_rebuild?
 
-      content_node = node_for_content(doc, &block)
+      content_node = node_for_content(doc, &)
       result =
         @items.keys.collect do |item|
           val = if self.class.gsl_available
@@ -201,10 +201,10 @@ module Classifier
     # calculated vectors instead of their full versions. This is useful when
     # you're trying to perform operations on content that is much smaller than
     # the text you're working with. search uses this primitive.
-    def proximity_norms_for_content(doc, &block)
+    def proximity_norms_for_content(doc, &)
       return [] if needs_rebuild?
 
-      content_node = node_for_content(doc, &block)
+      content_node = node_for_content(doc, &)
       result =
         @items.keys.collect do |item|
           val = if self.class.gsl_available
@@ -229,7 +229,7 @@ module Classifier
 
       carry = proximity_norms_for_content(string)
       result = carry.collect { |x| x[0] }
-      result[0..max_nearest - 1]
+      result[0..(max_nearest - 1)]
     end
 
     # This function takes content and finds other documents
@@ -245,7 +245,7 @@ module Classifier
       carry =
         proximity_array_for_content(doc, &block).reject { |pair| pair[0] == doc }
       result = carry.collect { |x| x[0] }
-      result[0..max_nearest - 1]
+      result[0..(max_nearest - 1)]
     end
 
     # This function uses a voting system to categorize documents, based on
@@ -257,17 +257,17 @@ module Classifier
     # text. A cutoff of 1 means that every document in the index votes on
     # what category the document is in. This may not always make sense.
     #
-    def classify(doc, cutoff = 0.30, &block)
-      votes = vote(doc, cutoff, &block)
+    def classify(doc, cutoff = 0.30, &)
+      votes = vote(doc, cutoff, &)
 
       ranking = votes.keys.sort_by { |x| votes[x] }
       ranking[-1]
     end
 
-    def vote(doc, cutoff = 0.30, &block)
+    def vote(doc, cutoff = 0.30, &)
       icutoff = (@items.size * cutoff).round
-      carry = proximity_array_for_content(doc, &block)
-      carry = carry[0..icutoff - 1]
+      carry = proximity_array_for_content(doc, &)
+      carry = carry[0..(icutoff - 1)]
       votes = {}
       carry.each do |pair|
         categories = @items[pair[0]].categories
@@ -291,8 +291,8 @@ module Classifier
     #
     #
     # See classify() for argument docs
-    def classify_with_confidence(doc, cutoff = 0.30, &block)
-      votes = vote(doc, cutoff, &block)
+    def classify_with_confidence(doc, cutoff = 0.30, &)
+      votes = vote(doc, cutoff, &)
       votes_sum = votes.values.inject(0.0) { |sum, v| sum + v }
       return [nil, nil] if votes_sum.zero?
 
@@ -309,7 +309,7 @@ module Classifier
       raise 'Requested stem ranking on non-indexed content!' unless @items[doc]
 
       arr = node_for_content(doc).lsi_vector.to_a
-      top_n = arr.sort.reverse[0..count - 1]
+      top_n = arr.sort.reverse[0..(count - 1)]
       top_n.collect { |x| @word_list.word_for_index(arr.index(x)) }
     end
 

--- a/test/extensions/word_hash_test.rb
+++ b/test/extensions/word_hash_test.rb
@@ -2,95 +2,108 @@ require_relative '../test_helper'
 
 class StringExtensionsTest < Minitest::Test
   def test_word_hash
-    hash = { good: 1, "!": 1, hope: 1, "'": 1, ".": 1, love: 1, word: 1, them: 1, test: 1 }
+    hash = { good: 1, '!': 1, hope: 1, "'": 1, '.': 1, love: 1, word: 1, them: 1, test: 1 }
+
     assert_equal hash, "here are some good words of test's. I hope you love them!".word_hash
   end
 
   def test_clean_word_hash
     hash = { good: 1, word: 1, hope: 1, love: 1, them: 1, test: 1 }
+
     assert_equal hash, "here are some good words of test's. I hope you love them!".clean_word_hash
   end
 end
 
 class ArrayExtensionsTest < Minitest::Test
   def test_monkey_path_array_sum
-    assert_equal [1, 2, 3].sum_with_identity, 6
+    assert_equal 6, [1, 2, 3].sum_with_identity
   end
 
   def test_summing_a_nil_array
-    assert_equal [nil].sum_with_identity, 0
+    assert_equal 0, [nil].sum_with_identity
   end
 
   def test_summing_an_empty_array
-    assert_equal Array[].sum_with_identity, 0
+    assert_equal 0, [].sum_with_identity
   end
 
   def test_sum_with_block
-    assert_equal [1, 2, 3].sum_with_identity { |x| x * 2 }, 12.0
+    assert_in_delta([1, 2, 3].sum_with_identity { |x| x * 2 }, 12.0)
   end
 
   def test_sum_with_custom_identity
-    assert_equal [].sum_with_identity(100), 100.0
+    assert_in_delta([].sum_with_identity(100), 100.0)
   end
 end
 
 class StringPunctuationTest < Minitest::Test
   def test_without_punctuation_basic
-    result = "Hello, world!".without_punctuation
-    assert_equal "Hello  world ", result
+    result = 'Hello, world!'.without_punctuation
+
+    assert_equal 'Hello  world ', result
   end
 
   def test_without_punctuation_many_symbols
     result = "Hello (greeting's), with {braces} < >...?".without_punctuation
-    assert_equal "Hello  greetings   with  braces         ", result
+
+    assert_equal 'Hello  greetings   with  braces         ', result
   end
 
   def test_without_punctuation_empty_string
-    result = "".without_punctuation
-    assert_equal "", result
+    result = ''.without_punctuation
+
+    assert_equal '', result
   end
 
   def test_without_punctuation_no_punctuation
-    result = "plain text here".without_punctuation
-    assert_equal "plain text here", result
+    result = 'plain text here'.without_punctuation
+
+    assert_equal 'plain text here', result
   end
 
   def test_without_punctuation_only_punctuation
-    result = "!@#$%^&*()".without_punctuation
-    assert_equal "          ", result
+    result = "!@\#$%^&*()".without_punctuation
+
+    assert_equal '          ', result
   end
 end
 
 class VectorExtensionsTest < Minitest::Test
   def test_magnitude_basic
     vec = Vector[3, 4]
+
     assert_in_delta 5.0, vec.magnitude, 0.001
   end
 
   def test_magnitude_zero_vector
     vec = Vector[0, 0, 0]
-    assert_equal 0.0, vec.magnitude
+
+    assert_in_delta(0.0, vec.magnitude)
   end
 
   def test_magnitude_single_element
     vec = Vector[5]
-    assert_equal 5.0, vec.magnitude
+
+    assert_in_delta(5.0, vec.magnitude)
   end
 
   def test_magnitude_negative_values
     vec = Vector[-3, -4]
+
     assert_in_delta 5.0, vec.magnitude, 0.001
   end
 
   def test_normalize_basic
     vec = Vector[3, 4]
     normalized = vec.normalize
+
     assert_in_delta 1.0, normalized.magnitude, 0.001
   end
 
   def test_normalize_unit_vector
     vec = Vector[1, 0, 0]
     normalized = vec.normalize
+
     assert_in_delta 1.0, normalized[0], 0.001
     assert_in_delta 0.0, normalized[1], 0.001
   end
@@ -98,6 +111,7 @@ class VectorExtensionsTest < Minitest::Test
   def test_normalize_preserves_direction
     vec = Vector[2, 0]
     normalized = vec.normalize
+
     assert_in_delta 1.0, normalized[0], 0.001
     assert_in_delta 0.0, normalized[1], 0.001
   end
@@ -107,17 +121,20 @@ class MatrixExtensionsTest < Minitest::Test
   def test_diag_creates_diagonal_matrix
     result = Matrix.diag([1, 2, 3])
     expected = Matrix.diagonal(1, 2, 3)
+
     assert_equal expected, result
   end
 
   def test_trans_alias
     matrix = Matrix[[1, 2], [3, 4]]
+
     assert_equal matrix.transpose, matrix.trans
   end
 
   def test_matrix_element_assignment
     matrix = Matrix[[1, 2], [3, 4]]
     matrix[0, 1] = 99
+
     assert_equal 99, matrix[0, 1]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.start do
   enable_coverage :branch
 end
 
-$:.unshift(File.dirname(__FILE__) + '/../lib')
+$LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib")
 
 require 'minitest'
 require 'minitest/autorun'


### PR DESCRIPTION
## Summary
Add RuboCop with rubocop-minitest for consistent code style and automated linting in CI.

## Changes
- Add `rubocop` and `rubocop-minitest` gems
- Create `.rubocop.yml` with project-specific configuration
- Auto-correct 151 style offenses
- Add `respond_to_missing?` to Bayes class (fixes RuboCop warning)
- Add lint job to CI workflow (runs on Ruby 3.3)

## Configuration Highlights
- Exclude legacy `bin/` and `install.rb` files
- Exclude complex algorithm files from metrics checks (SVD, LSI)
- Single quotes for strings
- Minitest best practices enabled

## Files Excluded from Metrics
Some files contain complex mathematical algorithms that exceed standard metrics. These are tracked in #60 for future refactoring:
- `lib/classifier/extensions/vector.rb` (SVD algorithm)
- `lib/classifier/lsi/content_node.rb` (vector operations)
- `lib/classifier/lsi.rb` (index building)

## CI
New `lint` job runs RuboCop on every push/PR.

Fixes #56