### PR TITLE
Improve GSL warning with suppression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,27 @@ Classifier is a general module to allow Bayesian and other types of classificati
 
 ## Dependencies
 
-If you install Classifier from source, you'll need to install Roman Shterenzon's fast-stemmer gem with RubyGems as follows:
+The `fast-stemmer` gem is required:
 
     gem install fast-stemmer
 
-If you would like to speed up LSI classification by at least 10x, please install the following libraries:
-GNU GSL:: http://www.gnu.org/software/gsl
-rb-gsl:: https://github.com/SciRuby/rb-gsl
+### Optional: GSL for Faster LSI
 
-Notice that LSI will work without these libraries, but as soon as they are installed, Classifier will make use of them. No configuration changes are needed, we like to keep things ridiculously easy for you.
+For 10x faster LSI classification, install the GNU Scientific Library and its Ruby bindings:
+
+    # macOS
+    brew install gsl
+    gem install gsl
+
+    # Ubuntu/Debian
+    apt-get install libgsl-dev
+    gem install gsl
+
+LSI works without GSL using a pure Ruby implementation. When GSL is installed, Classifier automatically uses it with no configuration needed.
+
+To suppress the GSL notice when not using it:
+
+    SUPPRESS_GSL_WARNING=true ruby your_script.rb
 
 ## Bayes
 

--- a/lib/classifier/lsi.rb
+++ b/lib/classifier/lsi.rb
@@ -17,11 +17,13 @@ begin
   raise LoadError if ENV['NATIVE_VECTOR'] == 'true'
   raise LoadError unless Gem::Specification.find_all_by_name('gsl').any?
 
-  require 'gsl' # requires https://github.com/SciRuby/rb-gsl/
+  require 'gsl'
   require 'classifier/extensions/vector_serialize'
   Classifier::LSI.gsl_available = true
 rescue LoadError
-  warn 'Notice: for 10x faster LSI support in the classifier gem, please install the gsl gem'
+  unless ENV['SUPPRESS_GSL_WARNING'] == 'true'
+    warn 'Notice: for 10x faster LSI, run `gem install gsl`. Set SUPPRESS_GSL_WARNING=true to hide this.'
+  end
   Classifier::LSI.gsl_available = false
   require 'classifier/extensions/vector'
 end


### PR DESCRIPTION
## Summary
- Add `SUPPRESS_GSL_WARNING=true` environment variable to silence the GSL notice
- Update warning message with clear install instructions (`gem install gsl`)
- Modernize README with platform-specific GSL installation steps (macOS/Ubuntu)
- Rename README.markdown to README.md

## Context
The `gsl` gem (v2.1.0.3) is available on RubyGems and actively maintained. This PR addresses user concerns about the warning being noisy by providing a way to suppress it, while also clarifying installation instructions.

## Test plan
- [x] All 77 tests pass
- [x] Warning appears when GSL not available
- [x] Warning suppressed with `SUPPRESS_GSL_WARNING=true`

Closes #41