### PR TITLE
Fix LSI dimension mismatch with native Ruby SVD

### DIFF
--- a/lib/classifier/lsi.rb
+++ b/lib/classifier/lsi.rb
@@ -144,7 +144,7 @@ module Classifier
         tdm = Matrix.rows(tda).trans
         ntdm = build_reduced_matrix(tdm, cutoff)
 
-        ntdm.row_size.times do |col|
+        ntdm.column_size.times do |col|
           next unless doc_list[col]
 
           column = ntdm.column(col)
@@ -332,7 +332,13 @@ module Classifier
         s[ord] = 0.0 if s[ord] < s_cutoff
       end
       # Reconstruct the term document matrix, only with reduced rank
-      u * (self.class.gsl_available ? GSL::Matrix : ::Matrix).diag(s) * v.trans
+      result = u * (self.class.gsl_available ? GSL::Matrix : ::Matrix).diag(s) * v.trans
+
+      # Native Ruby SVD returns transposed dimensions when row_size < column_size
+      # Ensure result matches input dimensions
+      result = result.trans if !self.class.gsl_available && result.row_size != matrix.row_size
+
+      result
     end
 
     def node_for_content(item, &block)

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -307,4 +307,24 @@ class LSITest < Minitest::Test
 
     refute_predicate lsi, :needs_rebuild?
   end
+
+  def test_large_similar_document_sets
+    # Regression test for issue #72
+    # When many similar documents create few unique terms (M < N),
+    # native Ruby SVD returns transposed dimensions causing ErrDimensionMismatch
+    lsi = Classifier::LSI.new auto_rebuild: false
+
+    10.times do |i|
+      lsi.add_item "This text deals with dogs. Dogs number #{i}.", 'Dog'
+    end
+    10.times do |i|
+      lsi.add_item "This text deals with cats. Cats number #{i}.", 'Cat'
+    end
+
+    lsi.build_index
+
+    result = lsi.classify('Dogs are great pets')
+
+    assert_equal 'Dog', result
+  end
 end


### PR DESCRIPTION
## Summary
- Fix `ExceptionForMatrix::ErrDimensionMismatch` when classifying with 10+ similar documents using native Ruby SVD
- Transpose reduced matrix when native SVD returns swapped dimensions
- Iterate over columns (documents) instead of rows (terms) in build_index

## Root Cause
Native Ruby SVD returns transposed dimensions when `row_size < column_size` (common case: few unique terms, many documents). This caused query vectors (5 elements) to be compared against document vectors (20 elements).

## Test Plan
- [x] Reproduction case from #72 now works
- [x] All 85 tests pass with `NATIVE_VECTOR=true`
- [x] All 85 tests pass with GSL

Fixes #72