### PR TITLE
Implement proper Laplace smoothing in Bayes classifier

### DIFF
--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -60,13 +60,11 @@ class LSITest < Minitest::Test
     lsi.add_item @str5, 'Bird'
     bayes.train_bird @str5
 
-    # We're talking about dogs. Even though the text matches the corpus on
-    # cats better.  Dogs have more semantic weight than cats. So bayes
-    # will fail here, but the LSI recognizes content.
+    # Both classifiers should recognize this is about dogs
     tricky_case = 'This text revolves around dogs.'
 
     assert_equal 'Dog', lsi.classify(tricky_case)
-    assert_equal 'Cat', bayes.classify(tricky_case)
+    assert_equal 'Dog', bayes.classify(tricky_case)
   end
 
   def test_recategorize_interface


### PR DESCRIPTION
## Summary
- Replace magic number `0.1` with proper add-one (Laplace) smoothing
- Formula: `P(word|category) = (count + 1) / (total + vocab_size)`
- Smoothing now scales correctly with vocabulary size

## Before
```ruby
s = category_words.key?(word) ? category_words[word] : 0.1  # Magic number
score += Math.log(s / total)
```

## After
```ruby
count = category_words[word] || 0
score += Math.log((count + 1) / smoothed_total)  # Laplace smoothing
```

## Test Plan
- [x] 5 new Laplace smoothing tests added
- [x] All 90 tests pass
- [x] Bayes now correctly classifies edge cases it previously got wrong

Fixes #64