### PR TITLE
Add GitHub Actions workflow for automated gem releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ruby.yml
+
+  release:
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '4.0'
+        bundler-cache: true
+
+    - name: Build gem
+      run: gem build classifier.gemspec
+
+    - name: Push to RubyGems
+      env:
+        GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      run: gem push classifier-*.gem
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: classifier-*.gem
+        generate_release_notes: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release.yml` to automate gem publishing when version tags are pushed.

## Workflow
1. Triggered by pushing tags matching `v*` (e.g., `v1.4.5`)
2. Runs full test suite
3. Builds gem
4. Pushes to RubyGems
5. Creates GitHub Release with auto-generated release notes

## Setup Required
Add `RUBYGEMS_API_KEY` to repository secrets:
1. Go to Settings → Secrets and variables → Actions
2. Add new secret `RUBYGEMS_API_KEY` with your RubyGems API key

## Usage
```bash
# Update version in classifier.gemspec
# Commit changes
git tag v1.4.5
git push origin v1.4.5
```

Fixes #79