### PR TITLE
Add rubyclassifier.com links to README and gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A Ruby library for text classification using Bayesian and Latent Semantic Indexing (LSI) algorithms.
 
+**[Documentation](https://rubyclassifier.com/docs)** · **[Tutorials](https://rubyclassifier.com/docs/tutorials)** · **[Guides](https://rubyclassifier.com/docs/guides)**
+
 ## Table of Contents
 
 - [Installation](#installation)
@@ -112,8 +114,8 @@ m.system.classify "new scientific discovery"
 
 ### Learn More
 
-- [Bayesian Filtering Explained](http://www.process.com/precisemail/bayesian_filtering.htm)
-- [Wikipedia: Bayesian Filtering](http://en.wikipedia.org/wiki/Bayesian_filtering)
+- [Bayes Basics Guide](https://rubyclassifier.com/docs/guides/bayes/basics) - In-depth documentation
+- [Build a Spam Filter Tutorial](https://rubyclassifier.com/docs/tutorials/spam-filter) - Step-by-step guide
 - [Paul Graham: A Plan for Spam](http://www.paulgraham.com/spam.html)
 
 ## LSI (Latent Semantic Indexing)
@@ -156,8 +158,8 @@ lsi.search "programming", 3
 
 ### Learn More
 
+- [LSI Basics Guide](https://rubyclassifier.com/docs/guides/lsi/basics) - In-depth documentation
 - [Wikipedia: Latent Semantic Analysis](http://en.wikipedia.org/wiki/Latent_semantic_analysis)
-- [C2 Wiki: Latent Semantic Indexing](http://www.c2.com/cgi/wiki?LatentSemanticIndexing)
 
 ## Performance
 

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -5,7 +5,13 @@ Gem::Specification.new do |s|
   s.description = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.author = 'Lucas Carlson'
   s.email = 'lucas@rufy.com'
-  s.homepage = 'https://github.com/cardmagic/classifier'
+  s.homepage = 'https://rubyclassifier.com'
+  s.metadata = {
+    'documentation_uri' => 'https://rubyclassifier.com/docs',
+    'source_code_uri' => 'https://github.com/cardmagic/classifier',
+    'bug_tracker_uri' => 'https://github.com/cardmagic/classifier/issues',
+    'changelog_uri' => 'https://github.com/cardmagic/classifier/releases'
+  }
   s.files = Dir['{lib,sig}/**/*.{rb,rbs}', 'ext/**/*.{c,h,rb}', 'bin/*', 'LICENSE', '*.md', 'test/*']
   s.extensions = ['ext/classifier/extconf.rb']
   s.license = 'LGPL'


### PR DESCRIPTION
## Summary
- Add documentation links to README header (Documentation · Tutorials · Guides)
- Update "Learn More" sections to link to rubyclassifier.com guides
- Update gemspec homepage to rubyclassifier.com
- Add metadata URIs (documentation, source code, bug tracker, changelog)