### PR TITLE
Release v2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    classifier (2.1.0)
+    classifier (2.2.0)
       fast-stemmer (~> 1.0)
       matrix
       mutex_m (~> 0.2)

--- a/classifier.gemspec
+++ b/classifier.gemspec
@@ -1,8 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'classifier'
-  s.version     = '2.1.0'
-  s.summary     = 'Text classification with Bayesian, LSI, and k-Nearest Neighbors algorithms.'
-  s.description = 'A Ruby library for text classification using Bayesian, LSI (Latent Semantic Indexing), and k-Nearest Neighbors (kNN) algorithms. Includes native C extension for fast LSI operations.'
+  s.version     = '2.2.0'
+  s.summary     = 'Text classification with Bayesian, LSI, Logistic Regression, kNN, and TF-IDF vectorization.'
+  s.description = 'A Ruby library for text classification featuring Naive Bayes, LSI (Latent Semantic Indexing), ' \
+                  'Logistic Regression, and k-Nearest Neighbors classifiers. Includes TF-IDF vectorization, ' \
+                  'streaming/incremental training, pluggable persistence backends, thread safety, and a native ' \
+                  'C extension for fast LSI operations.'
   s.author = 'Lucas Carlson'
   s.email = 'lucas@rufy.com'
   s.homepage = 'https://rubyclassifier.com'
@@ -12,6 +15,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/cardmagic/classifier/issues',
     'changelog_uri' => 'https://github.com/cardmagic/classifier/releases'
   }
+  s.required_ruby_version = '>= 3.1'
   s.files = Dir['{lib,sig}/**/*.{rb,rbs}', 'ext/**/*.{c,h,rb}', 'bin/*', 'LICENSE', '*.md', 'test/*']
   s.extensions = ['ext/classifier/extconf.rb']
   s.license = 'LGPL'


### PR DESCRIPTION
## Summary

- Bump version to 2.2.0
- Update gemspec summary and description to reflect new features since 2.1.0:
  - Logistic Regression classifier
  - TF-IDF vectorization
  - Streaming/incremental training
  - Pluggable persistence backends
  - Thread safety improvements
- Add `required_ruby_version >= 3.1` to match CI matrix

## Test plan

- [x] Verify `bundle install` works
- [x] Verify `bundle exec rake test` passes
- [x] Verify gem builds with `gem build classifier.gemspec`