### PR TITLE
ci: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,4 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
 
 version: 2
 updates:


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to automatically check for bundler dependency updates weekly
- Helps keep Ruby gem dependencies up to date with minimal manual effort

## Test plan
- [ ] Verify Dependabot runs on schedule and creates PRs for outdated dependencies