### PR TITLE
fix: force UTF-8 encoding for non-UTF8 locales

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    classifier (2.3.0)
+    classifier (2.3.1)
       fast-stemmer (~> 1.0)
       matrix
       mutex_m (~> 0.2)

--- a/exe/classifier
+++ b/exe/classifier
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Force UTF-8 encoding for proper handling of model data and user input
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 require 'classifier/cli'
 
 result = Classifier::CLI.new(ARGV).run

--- a/lib/classifier/version.rb
+++ b/lib/classifier/version.rb
@@ -1,3 +1,3 @@
 module Classifier
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end


### PR DESCRIPTION
## Summary
- Force UTF-8 encoding in CLI executable to prevent encoding errors in C/POSIX locales
- Bump version to 2.3.1

## Problem
When running `classifier` in environments with non-UTF8 locales (like Homebrew's test sandbox which uses `LC_ALL=C`), the CLI fails with:
```
Error: "\xC2" on US-ASCII
```

## Solution
Explicitly set `Encoding.default_external` and `Encoding.default_internal` to UTF-8 at CLI startup.

## Test
```bash
LC_ALL=C classifier -r sms-spam-filter "test message"
# Now works instead of failing with encoding error
```