### PR TITLE
fix: force UTF-8 encoding on HTTP response body + CLI docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    classifier (2.3.1)
+    classifier (2.3.2)
       fast-stemmer (~> 1.0)
       matrix
       mutex_m (~> 0.2)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,47 @@ Text classification in Ruby. Five algorithms, native performance, streaming supp
 gem 'classifier'
 ```
 
+Or install via Homebrew for CLI-only usage:
+
+```bash
+brew install classifier
+```
+
+## Command Line
+
+Classify text instantly with pre-trained models—no coding required:
+
+```bash
+# Detect spam
+classifier classify "You won a free iPhone!" -r sms-spam-filter
+# => spam
+
+# Analyze sentiment
+classifier classify "This movie was absolutely amazing!" -r imdb-sentiment
+# => positive
+
+# Detect emotions
+classifier classify "I'm so happy today!" -r emotion-detection
+# => joy
+
+# List all available models
+classifier models
+```
+
+Train your own model:
+
+```bash
+# Train from files
+classifier train positive reviews/good/*.txt
+classifier train negative reviews/bad/*.txt
+
+# Classify new text
+classifier classify "Great product, highly recommend"
+# => positive
+```
+
+[CLI Guide →](https://rubyclassifier.com/docs/guides/cli/basics)
+
 ## Quick Start
 
 ### Bayesian

--- a/lib/classifier/cli.rb
+++ b/lib/classifier/cli.rb
@@ -874,7 +874,7 @@ module Classifier
         return ''
       end
 
-      response.body
+      response.body.force_encoding(Encoding::UTF_8)
     end
   end
 end

--- a/lib/classifier/version.rb
+++ b/lib/classifier/version.rb
@@ -1,3 +1,3 @@
 module Classifier
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
 end


### PR DESCRIPTION
## Summary
- Force UTF-8 encoding on HTTP response body in CLI to fix encoding errors in non-UTF8 locales
- Add prominent CLI documentation to README with remote model examples

## Problem
When downloading remote models in environments with C/POSIX locales (like Homebrew's test sandbox), the HTTP response body defaults to ASCII-8BIT encoding, causing:
```
Error: "\xC2" from ASCII-8BIT to UTF-8
```

## Solution
Call `force_encoding(Encoding::UTF_8)` on the response body in `fetch_github_file`.

## README Updates
Added a new "Command Line" section after Installation showing:
- Pre-trained model usage with `-r` flag
- Training custom models from files
- Listing available models