### PR TITLE
chore(deps-dev): bump json from 2.18.0 to 2.19.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.18.0)
+    json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.9.0)


### PR DESCRIPTION
Replaces closed dependabot PR #143 after merge conflicts.