### PR TITLE
fix: resolve RuboCop Style/OneClassPerFile violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,3 +110,11 @@ Style/StringLiteralsInInterpolation:
 # Minitest assertions
 Minitest/MultipleAssertions:
   Max: 10
+
+# Allow multiple classes/modules in extension files that patch stdlib
+# and in test files that group related test classes
+Style/OneClassPerFile:
+  Exclude:
+    - 'lib/classifier/extensions/vector.rb'
+    - 'lib/classifier/lsi.rb'
+    - 'test/**/*'

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -691,7 +691,7 @@ class LSITest < Minitest::Test
 
     refute_nil lsi.singular_values
     assert_instance_of Array, lsi.singular_values
-    assert(lsi.singular_values.all? { |v| v.is_a?(Numeric) })
+    assert(lsi.singular_values.all?(Numeric))
     assert_predicate lsi.singular_values.size, :positive?
   end
 


### PR DESCRIPTION
## Summary

- Add `Style/OneClassPerFile` exclusions for extension files and tests
- Fix `Style/PredicateWithKind` offense using `all?(Numeric)` syntax

Fixes the lint job that's been failing on master since March 2026 due to newer RuboCop versions enforcing `Style/OneClassPerFile`.

The excluded patterns are legitimate:
- `lib/classifier/extensions/vector.rb` - patches stdlib `Vector` and `Matrix` classes
- `lib/classifier/lsi.rb` - module structure with nested definitions
- `test/**/*` - test files commonly group related test classes

## Test plan

- [x] `bundle exec rubocop` passes locally (47 files, no offenses)