### PR TITLE
docs: correct the Homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem 'classifier'
 Or install via Homebrew for CLI-only usage:
 
 ```bash
-brew install cardmagic/tap/classifier
+brew install classifier
 ```
 
 ## Command Line

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,5 +140,5 @@ $ classifier -m lsi related article.txt
 Homebrew installs the command line tools on their own:
 
 ```bash
-brew install cardmagic/tap/classifier
+brew install classifier
 ```


### PR DESCRIPTION
Found while auditing rubyclassifier.com, where the site had it right and the README had it wrong.

The formula moved to homebrew-core, and `cardmagic/homebrew-tap` no longer carries it:

```console
$ brew install cardmagic/tap/classifier
Error: No available formula or cask with the name "cardmagic/tap/classifier".
==> Searching for a previously deleted formula (in the last month)...
cardmagic/tap/classifier was deleted from cardmagic/tap in commit 09c4db3
```

`cardmagic/homebrew-tap/Formula` now holds only `messages.rb`, `notes.rb`, and `reminders.rb`.

The plain name resolves through homebrew-core and works:

```console
$ brew info classifier
==> classifier: stable 2.6.0 (bottled)
Text classification with Bayesian, LSI, Logistic Regression, and kNN
https://rubyclassifier.com
```

Fixed in `README.md` and `docs/cli.md`.

Note: homebrew-core is at 2.6.0 and has not yet picked up the 2.7.0 release from today.

Verified: 761 runs / 0 failures, static doc checks pass.
